### PR TITLE
fix: Translate issue content detail detail breaking

### DIFF
--- a/src/actions/translate_issues.py
+++ b/src/actions/translate_issues.py
@@ -60,7 +60,7 @@ def format_translations(title_translations, body_translations, original_content,
     for language, translation in body_translations.items():
         if translation and language != original_language:
             language_name = LANGUAGE_NAMES.get(language, language.capitalize())
-            formatted_parts.append(f"\n\n<details>\n<summary><b>{language_name}</b></summary>\n\n{translation}</details><br>")
+            formatted_parts.append(f"\n\n<details>\n<summary><b>{language_name}</b></summary>\n\n{translation}\n</details><br>")
     
     original_lang_name = LANGUAGE_NAMES.get(original_language, original_language.capitalize())
     formatted_parts.append(f"<b>{ORIGINAL_CONTENT_MARKER}</b>\n{original_content}")


### PR DESCRIPTION
## Why

Issueの翻訳時に最後にコードブロックが来る際に、うまく表示されない問題がありほかでは対応されていたがIssueだけ残されていたので対応

## What

- Issueも、他と同様に translationのコンテンツのあとに改行を追加

