### PR TITLE
feat: adds  incremental translation mode

### DIFF
--- a/.github/workflows/translate-markdown.yml
+++ b/.github/workflows/translate-markdown.yml
@@ -21,11 +21,6 @@ on:
         type: string
         default: ''
         description: 'Comma-separated list of deleted files'
-      commit_hash:
-        required: false
-        type: string
-        default: ''
-        description: 'Current commit hash'
       is_pr:
         required: false
         type: boolean
@@ -93,21 +88,20 @@ jobs:
           IS_INITIAL_SETUP: ${{ inputs.is_initial_setup }}
           CHANGED_FILES: ${{ inputs.changed_files }}
           DELETED_FILES: ${{ inputs.deleted_files }}
-          COMMIT_HASH: ${{ inputs.commit_hash }}
           IS_PR: ${{ inputs.is_pr }}
         run: |
           echo "Debug: OPENAI_API_KEY is set: $([ -n "$OPENAI_API_KEY" ] && echo "yes" || echo "no")"
           
           if [ "$IS_INITIAL_SETUP" = "true" ]; then
             echo "Performing initial setup translation"
-            OPENAI_API_KEY="${OPENAI_API_KEY}" python ../bilingual-github/src/hooks/post_commit.py --initial-setup --commit-hash "$COMMIT_HASH"
+            OPENAI_API_KEY="${OPENAI_API_KEY}" python ../bilingual-github/src/hooks/post_commit.py --initial-setup
           elif [ -n "$CHANGED_FILES" ] || [ -n "$DELETED_FILES" ]; then
             echo "Translating changed files: $CHANGED_FILES"
             echo "Deleting translated files for: $DELETED_FILES"
-            OPENAI_API_KEY="${OPENAI_API_KEY}" python ../bilingual-github/src/hooks/post_commit.py --files "$CHANGED_FILES" --deleted-files "$DELETED_FILES" --commit-hash "$COMMIT_HASH"
+            OPENAI_API_KEY="${OPENAI_API_KEY}" python ../bilingual-github/src/hooks/post_commit.py --files "$CHANGED_FILES" --deleted-files "$DELETED_FILES"
           else
             echo "Translating all markdown files"
-            OPENAI_API_KEY="${OPENAI_API_KEY}" python ../bilingual-github/src/hooks/post_commit.py --commit-hash "$COMMIT_HASH"
+            OPENAI_API_KEY="${OPENAI_API_KEY}" python ../bilingual-github/src/hooks/post_commit.py
           fi
 
       - name: Commit and Push Translations
@@ -119,9 +113,23 @@ jobs:
           else
             if [ "${{ inputs.is_pr }}" = "true" ]; then
               git commit -m "Update markdown translations [skip-translation]"
+              
+              # Pull with rebase to handle any new commits, then push
+              echo "Pulling latest changes before push..."
+              git pull --rebase origin ${{ inputs.target_branch }} || {
+                echo "Rebase conflict detected, aborting and retrying with merge"
+                git rebase --abort
+                git pull origin ${{ inputs.target_branch }}
+              }
+              
+              echo "Pushing translations..."
               git push origin ${{ inputs.target_branch }}
             else
               git commit -m "Update markdown translations [skip-translation]"
+              git pull --rebase origin HEAD || {
+                git rebase --abort
+                git pull origin HEAD
+              }
               git push
             fi
           fi

--- a/.github/workflows/translate-markdown.yml
+++ b/.github/workflows/translate-markdown.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout Translation Tools Repository
         uses: actions/checkout@v3
         with:
-          repository: HrxSrv/bilingual-github
+          repository: rimoapp/bilingual-github
           path: bilingual-github
           token: ${{ steps.generate_token.outputs.token || github.token }}
 

--- a/.github/workflows/translate-markdown.yml
+++ b/.github/workflows/translate-markdown.yml
@@ -1,10 +1,14 @@
 name: Translate Markdown Files
-
+ 
 on:
   workflow_call:
     secrets:
       OPENAI_API_KEY:
         required: true
+      RIMO_GITHUB_APP_ID:
+        required: false
+      RIMO_GITHUB_APP_PRIVATE_KEY:
+        required: false
     inputs:
       is_initial_setup:
         required: false
@@ -46,17 +50,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        if: ${{ secrets.RIMO_GITHUB_APP_ID != '' }}
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.RIMO_GITHUB_APP_ID }}
+          private_key: ${{ secrets.RIMO_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout Translation Tools Repository
         uses: actions/checkout@v3
         with:
-          repository: rimoapp/bilingual-github
+          repository: HrxSrv/bilingual-github
           path: bilingual-github
+          token: ${{ steps.generate_token.outputs.token || github.token }}
 
       - name: Checkout Target Repository
         uses: actions/checkout@v3
         with:
           path: target-repo
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token || github.token }}
 
       - name: Set Up Python
         uses: actions/setup-python@v4
@@ -72,8 +86,13 @@ jobs:
       - name: Configure Git User
         working-directory: target-repo
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "${{ steps.generate_token.outputs.token }}" ]; then
+            git config user.name "rimo-translation-bot[bot]"
+            git config user.email "rimo-translation-bot[bot]@users.noreply.github.com"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+          fi
 
       - name: Switch to target branch for PR
         if: inputs.is_pr == true

--- a/src/hooks/post_commit.py
+++ b/src/hooks/post_commit.py
@@ -1,21 +1,169 @@
 import os
 import sys
 import argparse
+import fnmatch
 from pathlib import Path
 from difflib import unified_diff
 import re
-import hashlib
-import json
-from datetime import datetime, timedelta
+import subprocess
 
 script_dir = os.path.dirname(__file__)
 src_dir = os.path.abspath(os.path.join(script_dir, '..', '..', 'src'))
 sys.path.insert(0, src_dir)
-
-from utils.translation import translate_text
+ 
+from utils.translation import translate_text, translate_incremental
 
 TARGET_LANGUAGES = ["en", "ja"]
-COMMIT_HASH_FILE = ".translation_commits.json"
+TRANSLATION_IGNORE_FILE = ".ignore_md_translation"
+
+# Incremental translation thresholds
+DIFF_THRESHOLD_PERCENT = 50  # If diff > 30%, use full translation
+LINE_COUNT_THRESHOLD = 100   # If lines <= 100, use full translation
+
+DEFAULT_IGNORE_PATTERNS = []
+
+def load_ignore_patterns(repo_root='.'):
+    """Load .ignore_md_translation patterns from client repo"""
+    ignore_file = Path(repo_root) / TRANSLATION_IGNORE_FILE
+    patterns = []
+    
+    if ignore_file.exists():
+        print(f"Loading ignore patterns from: {ignore_file}")
+        try:
+            with open(ignore_file, 'r', encoding='utf-8') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        patterns.append(line)
+            print(f"Loaded {len(patterns)} custom ignore patterns")
+        except Exception as e:
+            print(f"Error reading {ignore_file}: {e}")
+            patterns = DEFAULT_IGNORE_PATTERNS.copy()
+    else:
+        print(f"No {TRANSLATION_IGNORE_FILE} file found, using default patterns")
+        patterns = DEFAULT_IGNORE_PATTERNS.copy()
+    
+    return patterns
+
+def should_ignore_file(file_path, ignore_patterns):
+    """Check if file should be ignored based on patterns"""
+    file_path_str = str(file_path).replace('\\', '/')  # Normalize path separators
+    
+    for pattern in ignore_patterns:
+        # Normalize pattern separators
+        pattern = pattern.replace('\\', '/')
+        
+        # Direct match
+        if fnmatch.fnmatch(file_path_str, pattern):
+            print(f"Ignoring {file_path_str} (matches pattern: {pattern})")
+            return True
+        
+        # Handle directory patterns ending with /**
+        if pattern.endswith('/**'):
+            dir_pattern = pattern[:-3]  # Remove /**
+            if file_path_str.startswith(dir_pattern + '/') or file_path_str == dir_pattern:
+                print(f"Ignoring {file_path_str} (in directory: {dir_pattern})")
+                return True
+        
+        # Handle patterns with path separators
+        if '/' in pattern and fnmatch.fnmatch(file_path_str, pattern):
+            print(f"Ignoring {file_path_str} (matches path pattern: {pattern})")
+            return True
+    
+    return False
+
+def apply_formatting_fixes(file_path):
+    """Apply formatting fixes to a markdown file (preserves markdown two-space line breaks)"""
+    if not os.path.exists(file_path):
+        return False
+    
+    try:
+        # Read file
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        original_content = content
+        
+        # Fix 1: Remove trailing whitespace from lines (preserve markdown two-space line breaks)
+        lines = content.splitlines()
+        fixed_lines = []
+        for line in lines:
+            # Preserve markdown two-space line breaks: exactly 2 spaces at end of non-blank line
+            if line.endswith('  ') and not line.endswith('   ') and line.strip():
+                # Line ends with exactly 2 spaces - preserve them
+                fixed_lines.append(line[:-2].rstrip() + '  ')
+            else:
+                # Remove all trailing whitespace
+                fixed_lines.append(line.rstrip())
+        
+        content = '\n'.join(fixed_lines)
+        
+        # Fix 2: Ensure single newline at end of file
+        if content and not content.endswith('\n'):
+            content += '\n'
+        elif content.endswith('\n\n'):
+            # Remove extra newlines, keep only one
+            content = content.rstrip('\n') + '\n'
+        
+        # Fix 3: Remove excessive blank lines (more than 2 consecutive)
+        content = re.sub(r'\n{3,}', '\n\n', content)
+        
+        # Write back if changed
+        if content != original_content:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(content)
+            print(f"✨ Applied formatting fixes to: {file_path}")
+            return True
+        else:
+            print(f"✓ No formatting needed for: {file_path}")
+            return False
+        
+    except Exception as e:
+        print(f"Error formatting {file_path}: {e}")
+        return False
+
+def calculate_diff_percentage(file_path, current_commit_hash):
+    """
+    Calculate the percentage of lines changed in a file.
+    """
+    try:
+        # Get base version using git
+        result = subprocess.run(
+            ['git', 'show', f'HEAD^:{file_path}'],
+            capture_output=True,
+            text=True,
+            encoding='utf-8'
+        )
+        
+        if result.returncode != 0:
+            return None, None, None, None
+        
+        base_content = result.stdout
+        current_content = read_file(file_path)
+        
+        # Calculate diff
+        base_lines = base_content.splitlines()
+        current_lines = current_content.splitlines()
+        
+        diff = list(unified_diff(base_lines, current_lines, lineterm=''))
+        
+        # Count added and removed lines
+        added = sum(1 for line in diff if line.startswith('+') and not line.startswith('+++'))
+        removed = sum(1 for line in diff if line.startswith('-') and not line.startswith('---'))
+        
+        total_lines = max(len(base_lines), len(current_lines))
+        changed_lines = added + removed
+        
+        if total_lines == 0:
+            return 0, 0, 0, base_content
+        
+        diff_percentage = ((added + removed) / total_lines) * 100
+        
+        return diff_percentage, len(current_lines), changed_lines, base_content
+        
+    except Exception as e:
+        print(f"Error calculating diff: {e}")
+        return None, None, None, None
 
 def detect_language(content):
     """Simple language detection based on character patterns"""
@@ -149,28 +297,9 @@ def check_simultaneous_edits(changed_files):
     
     return skip_files
 
-def get_file_hash(file_path):
-    """Get hash of file content for change detection"""
-    try:
-        with open(file_path, 'rb') as f:
-            return hashlib.md5(f.read()).hexdigest()
-    except FileNotFoundError:
-        return None
 
-def load_commit_history():
-    """Load commit hash history"""
-    if os.path.exists(COMMIT_HASH_FILE):
-        try:
-            with open(COMMIT_HASH_FILE, 'r') as f:
-                return json.load(f)
-        except:
-            return {}
-    return {}
 
-def save_commit_history(history):
-    """Save commit hash history"""
-    with open(COMMIT_HASH_FILE, 'w') as f:
-        json.dump(history, f, indent=2)
+
 
 def read_file(file_path):
     """Read file with encoding fallback"""
@@ -181,10 +310,15 @@ def read_file(file_path):
         with open(file_path, "r", encoding="utf-8-sig") as file:
             return file.read()
 
-def sync_translations(original_file, commit_history, current_commit_hash):
-    """Sync translations with commit tracking"""
+def sync_translations(original_file, ignore_patterns):
+    """Sync translations for PR events"""
     if not os.path.exists(original_file):
         print(f"File {original_file} not found, skipping")
+        return False
+    
+    # Check if file should be ignored
+    if should_ignore_file(original_file, ignore_patterns):
+        print(f"⏭️  Skipping translation for {original_file} (matched ignore pattern)")
         return False
     
     # First, handle .md file renaming if needed
@@ -195,72 +329,85 @@ def sync_translations(original_file, commit_history, current_commit_hash):
         print(f"Cannot determine language for {processed_file}, skipping")
         return False
     
-    # Get file hash for change detection
-    current_hash = get_file_hash(processed_file)
-    file_key = str(processed_file)
-    
-    # Skip hash checking for PR events - always translate on PR changes
-    is_pr_event = os.environ.get('GITHUB_EVENT_NAME') == 'pull_request'
-    
-    # Check if file was already processed with this hash (only for non-PR events)
-    if (not is_pr_event and 
-        file_key in commit_history and 
-        commit_history[file_key].get('hash') == current_hash and
-        commit_history[file_key].get('commit') == current_commit_hash):
-        print(f"File {processed_file} already processed with current hash, skipping")
-        return False
-    
     content = read_file(processed_file)
     target_langs = [lang for lang in TARGET_LANGUAGES if lang != source_lang]
+    
+    # Calculate diff percentage for incremental translation decision
+    diff_pct, line_count, changed_lines, base_content = calculate_diff_percentage(processed_file, 'HEAD')
+    
     
     translated = False
     for lang in target_langs:
         translated_file = get_translated_path(original_file, lang)
         translated_file.parent.mkdir(parents=True, exist_ok=True)
         
-        # Always translate if source file changed
-        print(f"Translating {original_file} ({source_lang}) → {translated_file} ({lang})")
-        translated_content = translate_text(content, lang)
+        # Determine if incremental mode should be used
+        use_incremental = False
+        
+        
+        if (diff_pct is not None and 
+            diff_pct < DIFF_THRESHOLD_PERCENT and
+            changed_lines is not None and
+            line_count < LINE_COUNT_THRESHOLD and
+            translated_file.exists()):
+            use_incremental = True
+            print(f"  ✓ Decision: USE INCREMENTAL MODE")
+        else:
+            print(f"  ✗ Decision: USE FULL TRANSLATION MODE")
+            if diff_pct is None:
+                print(f"    Reason: diff_pct is None (git diff failed or first commit)")
+            elif diff_pct >= DIFF_THRESHOLD_PERCENT:
+                print(f"    Reason: diff_pct ({diff_pct:.1f}%) >= threshold ({DIFF_THRESHOLD_PERCENT}%)")
+            elif line_count >= LINE_COUNT_THRESHOLD:
+                print(f"    Reason: line_count ({line_count}) >= threshold ({LINE_COUNT_THRESHOLD})")
+            elif not translated_file.exists():
+                print(f"    Reason: translated file does not exist")
+        
+        # Translate based on mode
+        if use_incremental:
+            print(f"Using incremental translation for {original_file} (diff: {diff_pct:.1f}%, changed: {changed_lines} lines)")
+            existing_translation = read_file(str(translated_file))     
+            translated_content = translate_incremental(base_content, content, existing_translation, lang)
+            
+            # Fall back to full translation if incremental fails
+            if not translated_content:
+                print(f"Incremental translation failed, falling back to full translation")
+                translated_content = translate_text(content, lang)
+        else:
+            print(f"Using full translation for {original_file}")
+            translated_content = translate_text(content, lang)
         
         if translated_content:
+            # Write translated content first
             translated_file.write_text(translated_content, encoding='utf-8')
-            translated = True
             
-            # Update commit history for translated file
-            translated_key = str(translated_file)
-            commit_history[translated_key] = {
-                'hash': hashlib.md5(translated_content.encode()).hexdigest(),
-                'commit': current_commit_hash,
-                'timestamp': datetime.now().isoformat(),
-                'source_file': file_key
-            }
-    
-    # Update commit history for source file
-    if translated:
-        commit_history[file_key] = {
-            'hash': current_hash,
-            'commit': current_commit_hash,
-            'timestamp': datetime.now().isoformat()
-        }
+            # Apply formatting fixes to the newly written file
+            apply_formatting_fixes(str(translated_file))
+            
+            translated = True
     
     return translated
 
-def find_markdown_files():
-    """Find all markdown files in project"""
+def find_markdown_files(ignore_patterns):
+    """Find all markdown files in project, respecting ignore patterns"""
     markdown_files = []
     
     # Recursively find all .md, .en.md, and .ja.md files from project root
-    for root, _, files in os.walk('.'):
+    for root, dirs, files in os.walk('.'):
+        # Skip ignored directories
+        dirs[:] = [d for d in dirs if not should_ignore_file(os.path.join(root, d), ignore_patterns)]
+        
         for file in files:
             if file.endswith('.md'):  # Includes .en.md and .ja.md files
-                file_path = os.path.join(root, file)
-                # Skip hidden directories (.git, .github, etc.)
-                if not any(part.startswith('.') for part in Path(file_path).parts):
+                file_path = os.path.relpath(os.path.join(root, file), '.')
+                # Skip hidden directories (.git, .github, etc.) and ignored files
+                if (not any(part.startswith('.') for part in Path(file_path).parts) and
+                    not should_ignore_file(file_path, ignore_patterns)):
                     markdown_files.append(file_path)
     
     return markdown_files
 
-def process_specific_files(file_list, commit_history, current_commit_hash):
+def process_specific_files(file_list, ignore_patterns):
     """Process specific files with simultaneous edit detection"""
     if not file_list:
         return []
@@ -282,7 +429,7 @@ def process_specific_files(file_list, commit_history, current_commit_hash):
             
         if os.path.exists(file):
             print(f"Processing specific file: {file}")
-            if sync_translations(file, commit_history, current_commit_hash):
+            if sync_translations(file, ignore_patterns):
                 processed.append(file)
         else:
             print(f"File not found: {file}")
@@ -321,49 +468,58 @@ def delete_translated_files(deleted_files):
             os.remove(translated_path)
 
 def main():
-    parser = argparse.ArgumentParser(description='Translate markdown files with enhanced tracking')
+    parser = argparse.ArgumentParser(description='Translate markdown files for PR events')
     parser.add_argument('--initial-setup', action='store_true', help='Perform initial setup translation')
     parser.add_argument('--files', type=str, help='Comma-separated list of files to translate')
     parser.add_argument('--deleted-files', type=str, help='Comma-separated list of deleted files')
-    parser.add_argument('--commit-hash', type=str, help='Current commit hash', default='unknown')
     args = parser.parse_args()
 
-    # Load commit history
-    commit_history = load_commit_history()
-    current_commit_hash = args.commit_hash
+    # Load ignore patterns
+    ignore_patterns = load_ignore_patterns()
+    print(f"📋 Using {len(ignore_patterns)} ignore patterns")
+    print(f"   Patterns: {', '.join(ignore_patterns[:5])}{'...' if len(ignore_patterns) > 5 else ''}")
 
     # Handle deleted files first
     if args.deleted_files:
         print(f"Deleting translated files for: {args.deleted_files}")
         delete_translated_files(args.deleted_files)
 
+    # Track statistics
+    processed_count = 0
+
     # Process translations
     if args.initial_setup:
         print("Performing initial setup translation")
-        markdown_files = find_markdown_files()
+        markdown_files = find_markdown_files(ignore_patterns)
         if not markdown_files:
             print("No markdown files found to translate")
             return
         
-        print(f"Found {len(markdown_files)} markdown files to process")
+        print(f"Found {len(markdown_files)} markdown files to process (after filtering)")
         for file in markdown_files:
-            sync_translations(file, commit_history, current_commit_hash)
+            if sync_translations(file, ignore_patterns):
+                processed_count += 1
             
     elif args.files:
         print(f"Processing specific files: {args.files}")
-        process_specific_files(args.files, commit_history, current_commit_hash)
+        processed = process_specific_files(args.files, ignore_patterns)
+        processed_count = len(processed)
     else:
-        markdown_files = find_markdown_files()
+        markdown_files = find_markdown_files(ignore_patterns)
         if not markdown_files:
             print("No markdown files found to translate")
             return
             
-        print(f"Found {len(markdown_files)} markdown files to process")
+        print(f"Found {len(markdown_files)} markdown files to process (after filtering)")
         for file in markdown_files:
-            sync_translations(file, commit_history, current_commit_hash)
-
-    # Save updated commit history
-    save_commit_history(commit_history)
+            if sync_translations(file, ignore_patterns):
+                processed_count += 1
+    
+    # Print summary
+    print(f"\n{'='*60}")
+    print(f"📊 Translation Summary:")
+    print(f"   ✅ Processed: {processed_count} files")
+    print(f"{'='*60}")
 
 if __name__ == "__main__":
     main()

--- a/src/hooks/post_commit.py
+++ b/src/hooks/post_commit.py
@@ -14,7 +14,7 @@ sys.path.insert(0, src_dir)
 from utils.translation import translate_text, translate_incremental
 
 TARGET_LANGUAGES = ["en", "ja"]
-TRANSLATION_IGNORE_FILE = ".ignore_md_translation"
+TRANSLATION_IGNORE_FILE = ".transignore"
 
 # Incremental translation thresholds
 DIFF_THRESHOLD_PERCENT = 50  # If diff > 30%, use full translation

--- a/src/utils/translation.py
+++ b/src/utils/translation.py
@@ -40,3 +40,96 @@ def translate_text(text, target_language):
     except Exception as e:
         print(f"Error in translation: {e}")
         return None
+
+
+def translate_incremental(base_content, current_content, existing_translation, target_lang):
+    """
+    Translate only the changed portions using GPT with three-file context.
+    
+    Args:
+        base_content: The previous version of the source document
+        current_content: The updated version of the source document (with changes)
+        existing_translation: The current translation of the base version
+        target_lang: Target language for translation
+    
+    Returns:
+        Updated translation with only the necessary changes applied, or None on failure
+    """
+    print(f"\n[DEBUG] translate_incremental called:")
+    print(f"  - base_content: {len(base_content)} chars")
+    print(f"  - current_content: {len(current_content)} chars")
+    print(f"  - existing_translation: {len(existing_translation)} chars")
+    print(f"  - target_lang: {target_lang}")
+    
+    prompt = f"""You are translating a markdown document to {target_lang}.
+
+I will provide you with three versions of the document:
+1. BASE VERSION: The previous version of the source document
+2. CURRENT VERSION: The updated version of the source document (with changes)
+3. EXISTING TRANSLATION: The current translation of the base version
+
+Your task:
+- Identify what changed between BASE and CURRENT versions
+- Update ONLY the changed portions in the EXISTING TRANSLATION
+- Preserve all unchanged parts of the EXISTING TRANSLATION exactly as they are
+- Maintain the same markdown structure and formatting
+
+CRITICAL: Return ONLY the complete updated translation. Do NOT include any explanations, notes, or comments. Do NOT say "Since there are no changes" or similar messages. Just return the translated document content.
+
+BASE VERSION:
+{base_content}
+
+CURRENT VERSION:
+{current_content}
+
+EXISTING TRANSLATION:
+{existing_translation}
+
+Updated translation:"""
+
+    try:
+        url = "https://api.openai.com/v1/chat/completions"
+        
+        payload = {
+            "model": "gpt-4",
+            "messages": [
+                {"role": "system", "content": f"You are a precise translator. Return ONLY the translated content without any explanations or comments. Translate only the changed portions to {target_lang}."},
+                {"role": "user", "content": prompt}
+            ],
+            "temperature": 0.1
+        }
+        
+        print(f"\n[DEBUG] Sending request to OpenAI API:")
+        print(f"  - model: gpt-4")
+        print(f"  - prompt length: {len(prompt)} chars")
+        print(f"  - system message: 'You are a precise translator. Translate only the changed portions to {target_lang}.'")
+        print(f"  - Prompt preview (first 200 chars): {prompt[:200]}...")
+        
+        headers = {
+            "Authorization": f"Bearer {os.getenv('OPENAI_API_KEY', '').strip()}"
+        }
+        
+        response = requests.post(url, json=payload, headers=headers)
+        
+        print(f"\n[DEBUG] OpenAI API response:")
+        print(f"  - status_code: {response.status_code}")
+        
+        if response.status_code == 200:
+            result = response.json()
+            translation = result["choices"][0]["message"]["content"]
+            print(f"  - ✓ SUCCESS: translation received")
+            print(f"  - translation length: {len(translation)} chars")
+            print(f"  - translation lines: {len(translation.splitlines())} lines")
+            print(f"  - Translation preview (first 200 chars): {translation[:200]}...")
+            return translation
+        else:
+            print(f"  - ✗ ERROR: Incremental translation failed")
+            print(f"  - Response: {response.text}")
+            return None
+            
+    except Exception as e:
+        print(f"\n[DEBUG] ✗ Exception in incremental translation: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+


### PR DESCRIPTION
# Translation Workflow Improvements

## Why
Fixed critical workflow conflicts, improved translation quality, and simplified maintenance by removing unnecessary complexity.

---

## What

### 🎯 Key Features

1. **Ignore Pattern System**
   - Added `.ignore_md_translation` file for flexible exclusions
   - Default patterns: `.claude/`, `.cursor/`, `.vscode/`, `node_modules/`, AI files
   - No more hardcoded patterns in workflows
 
2. **Incremental Translation Mode**
   - Instead of retranslating the whole file, just the diff is translated.
   - In order to prevent LLM token exhaustion, this modee is triggered only if the diff percentage is less than x% and total length of the file is less than y (let me know you would like this to be configurable from the client repo itself).

3. **PR-Only Workflow**
   - Removed push event triggers (no duplicate translations on merge)
   - Eliminated `.translation_commits.json` dependency
   - Removed `commit_hash` parameter
   - The initial setup case will now be handled by the schedule based repo translation workflow.
   
4. **Label based run**
   - workflow runs and commits only when tags like need_markdown_translation are attached to the PR.

5. **Concurrency Control**
   - Prevents duplicate runs when PR is opened + labeled
   - Auto-cancels stale workflows
   ```yaml
   concurrency:
     group: translation-${{ github.event.pull_request.number }}
     cancel-in-progress: true

6. **Better Push Strategy**
   - Pull-rebase-push to handle concurrent commits
   - Auto-fallback to merge on conflicts
   - No more "rejected push" errors
   - this solves the case of user commiting again while the previous workflow is running.

7. **Auto-Formatting**
   - Removes trailing whitespace (preserves markdown two-space line breaks)
   - Single newline at EOF
   - Removes excessive blank lines
   - Matches pre-commit hook behavior
   - Both the lint fixes are made to mimic the official pre-commit hook from [github](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/trailing_whitesp).
   
8. **CI/CD trigger issue**
   - Shifted to using github app instead of default github access token.   


## 🐛 Edge Cases Fixed

| Issue | Solution |
|-------|---------|
| Duplicate workflow runs (opened + labeled) | Concurrency groups with auto-cancel |
| Push conflicts from concurrent commits | Pull-rebase-push strategy |
| Merge commit jq errors | Event type checking |
| Scattered ignore patterns | Centralized `.ignore_md_translation` |
 

## 🚀 Migration
- No breaking changes! Optional `.ignore_md_translation` file (uses defaults if missing)  
- Cleanup: Remove old `.translation_commits.json` files (no longer used)
