### PR TITLE
Changed translation ignore file name

### DIFF
--- a/src/hooks/post_commit.py
+++ b/src/hooks/post_commit.py
@@ -14,7 +14,7 @@ sys.path.insert(0, src_dir)
 from utils.translation import translate_text, translate_incremental
 
 TARGET_LANGUAGES = ["en", "ja"]
-TRANSLATION_IGNORE_FILE = ".transignore"
+TRANSLATION_IGNORE_FILE = ".md_ignore"
 
 # Incremental translation thresholds
 DIFF_THRESHOLD_PERCENT = 50  # If diff > 30%, use full translation


### PR DESCRIPTION
## Why

Translation Ignore file name is too vague.
## What

Changed the name to .md_ignore