### PR TITLE
Replace Unicode-based language detection with LLM

### DIFF
--- a/src/actions/translate_comments.py
+++ b/src/actions/translate_comments.py
@@ -1,13 +1,12 @@
 import sys
 import os
 from github import Github
-import re
 
 script_dir = os.path.dirname(__file__)
 src_dir = os.path.abspath(os.path.join(script_dir, '..', '..', 'src'))
 sys.path.append(src_dir)
 
-from utils.translation import translate_text
+from utils.translation import translate_text, detect_language
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "").strip()
 REPO_NAME = os.getenv("GITHUB_REPOSITORY", "").strip()
@@ -27,21 +26,6 @@ def get_original_content(content):
         parts = content.split(ORIGINAL_CONTENT_MARKER)
         return parts[1].strip()
     return content.strip()
-
-def detect_language(text):
-    # Unicode ranges for Japanese characters
-    HIRAGANA = '\u3040-\u309F'
-    KATAKANA = '\u30A0-\u30FF'
-    KANJI = '\u4E00-\u9FFF'
-    HALF_WIDTH_KATAKANA = '\uFF60-\uFF9F'
-    
-    # Check if text contains any Japanese character
-    jp_pattern = f'[{HIRAGANA}{KATAKANA}{KANJI}{HALF_WIDTH_KATAKANA}]'
-    has_japanese = bool(re.search(jp_pattern, text))
-    
-    # If any Japanese character is found, original is Japanese, translate to English
-    # Otherwise, original is English, translate to Japanese
-    return "ja" if has_japanese else "en"
 
 def get_target_languages(original_language):
     if original_language == "en":

--- a/src/actions/translate_issues.py
+++ b/src/actions/translate_issues.py
@@ -1,13 +1,12 @@
 import sys
 import os
-import re
 from github import Github
 
 script_dir = os.path.dirname(__file__)
 src_dir = os.path.abspath(os.path.join(script_dir, '..', '..', 'src'))
 sys.path.append(src_dir)
 
-from utils.translation import translate_text
+from utils.translation import translate_text, detect_language
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "").strip()
 REPO_NAME = os.getenv("GITHUB_REPOSITORY", "").strip()
@@ -26,21 +25,6 @@ def get_original_content(content):
         parts = content.split(ORIGINAL_CONTENT_MARKER)
         return parts[1].strip()
     return content.strip()
-
-def detect_language(text):
-    # Unicode ranges for Japanese characters
-    HIRAGANA = '\u3040-\u309F'
-    KATAKANA = '\u30A0-\u30FF'
-    KANJI = '\u4E00-\u9FFF'
-    HALF_WIDTH_KATAKANA = '\uFF60-\uFF9F'
-    
-    # Check if text contains any Japanese character
-    jp_pattern = f'[{HIRAGANA}{KATAKANA}{KANJI}{HALF_WIDTH_KATAKANA}]'
-    has_japanese = bool(re.search(jp_pattern, text))
-    
-    # If any Japanese character is found, original is Japanese, translate to English
-    # Otherwise, original is English, translate to Japanese
-    return "ja" if has_japanese else "en"
 
 def get_target_languages(original_language):
     if original_language == "en":

--- a/src/actions/translate_prs.py
+++ b/src/actions/translate_prs.py
@@ -7,7 +7,7 @@ script_dir = os.path.dirname(__file__)
 src_dir = os.path.abspath(os.path.join(script_dir, '..', '..', 'src'))
 sys.path.append(src_dir)
 
-from utils.translation import translate_text
+from utils.translation import translate_text, detect_language
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "").strip()
 REPO_NAME = os.getenv("GITHUB_REPOSITORY", "").strip()
@@ -30,21 +30,6 @@ def get_original_content(content):
         original = re.sub(r'^(<br>\s*)+', '', original)
         return original.strip()
     return content.strip()
-
-def detect_language(text):
-    # Unicode ranges for Japanese characters
-    HIRAGANA = '\u3040-\u309F'
-    KATAKANA = '\u30A0-\u30FF'
-    KANJI = '\u4E00-\u9FFF'
-    HALF_WIDTH_KATAKANA = '\uFF60-\uFF9F'
-    
-    # Check if text contains any Japanese character
-    jp_pattern = f'[{HIRAGANA}{KATAKANA}{KANJI}{HALF_WIDTH_KATAKANA}]'
-    has_japanese = bool(re.search(jp_pattern, text))
-    
-    # If any Japanese character is found, original is Japanese, translate to English
-    # Otherwise, original is English, translate to Japanese
-    return "ja" if has_japanese else "en"
 
 def get_target_languages(original_language):
     if original_language == "en":

--- a/src/hooks/post_commit.py
+++ b/src/hooks/post_commit.py
@@ -11,7 +11,7 @@ script_dir = os.path.dirname(__file__)
 src_dir = os.path.abspath(os.path.join(script_dir, '..', '..', 'src'))
 sys.path.insert(0, src_dir)
  
-from utils.translation import translate_text, translate_incremental
+from utils.translation import translate_text, translate_incremental, detect_language
 
 TARGET_LANGUAGES = ["en", "ja"]
 TRANSLATION_IGNORE_FILE = ".md_ignore"
@@ -164,18 +164,6 @@ def calculate_diff_percentage(file_path, current_commit_hash):
     except Exception as e:
         print(f"Error calculating diff: {e}")
         return None, None, None, None
-
-def detect_language(content):
-    """Simple language detection based on character patterns"""
-    # Count Japanese characters (Hiragana, Katakana, Kanji)
-    japanese_chars = len(re.findall(r'[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]', content))
-    total_chars = len(re.sub(r'\s', '', content))
-    
-    if total_chars == 0:
-        return "en"  # Default to English for empty files
-    
-    japanese_ratio = japanese_chars / total_chars
-    return "ja" if japanese_ratio > 0.1 else "en"
 
 def get_file_language(file_path):
     """Determine language based on file extension convention"""


### PR DESCRIPTION
## Summary

- Replaces Unicode character matching with LLM-based language detection using `gpt-4o-mini`
- Consolidates duplicated `detect_language()` functions into a single shared utility
- Adds a fallback to Unicode-based detection when the API fails, improving reliability

## Problem

The previous implementation detected language by checking if **any** Japanese character existed in the text. This caused incorrect detection for:

- Mixed content like `"Let's meet at 東京駅 tomorrow"`
- English text containing Japanese names or borrowed words
- Code samples with Japanese comments

## Solution

Introduce LLM-based language detection that understands context and identifies the **primary** language of the text, rather than relying solely on character presence.

## Test Plan

- [ ] Test with pure English text → should return `"en"`
- [ ] Test with pure Japanese text → should return `"ja"`
- [ ] Test with mixed content (primarily English with some Japanese) → should return `"en"`
- [ ] Test with mixed content (primarily Japanese with some English) → should return `"ja"`

Fixes #47
