### PR TITLE
Translate existing comments when label is attached

### DIFF
--- a/src/actions/translate_issues.py
+++ b/src/actions/translate_issues.py
@@ -66,11 +66,47 @@ def translate_issue(issue, original_content, original_language, issue_title, iss
     title_translations = translate_content(issue_title, original_language)
     body_translations = translate_content(issue_body, original_language)
     updated_body = format_translations(title_translations, body_translations, original_content, original_language)
-    
+
     if updated_body != issue.body:
         issue.edit(body=updated_body)
         return True
-    
+
+    return False
+
+
+def format_comment_translations(translations, original_content, original_language):
+    """Format translations for a comment (without title)."""
+    formatted_parts = []
+
+    for language, translation in translations.items():
+        if translation and language != original_language:
+            language_name = LANGUAGE_NAMES.get(language, language.capitalize())
+            formatted_parts.append(
+                f"<details>\n<summary><b>{language_name}</b></summary>\n\n{translation}\n</details><br>"
+            )
+
+    formatted_parts.append(f"<b>{ORIGINAL_CONTENT_MARKER}</b>\n{original_content}")
+
+    return "\n\n".join(formatted_parts)
+
+
+def translate_comment(comment):
+    """Translate a single comment. Returns True if translation was performed."""
+    if not comment.body:
+        return False
+
+    current_content = comment.body.strip()
+    original_content = get_original_content(current_content)
+
+    original_language = detect_language(original_content)
+    translations = translate_content(original_content, original_language)
+
+    if translations:
+        updated_body = format_comment_translations(translations, original_content, original_language)
+        if updated_body != comment.body:
+            comment.edit(body=updated_body)
+            return True
+
     return False
 
 def should_translate(issue):
@@ -88,27 +124,54 @@ def main():
     if not all([GITHUB_TOKEN, REPO_NAME, ISSUE_NUMBER]):
         print("Missing required environment variables")
         return
-    
+
     try:
         issue_number = int(ISSUE_NUMBER)
         g = Github(GITHUB_TOKEN)
         repo = g.get_repo(REPO_NAME)
         issue = repo.get_issue(number=issue_number)
-        
+
         if not should_translate(issue):
             print(f"Issue #{issue_number} does not require translation at this time.")
             return
-        
+
+        # Translate the issue body
+        print(f"Translating issue #{issue_number}...")
         original_content = get_original_content(issue.body)
         original_language = detect_language(original_content)
         issue_title = issue.title
         issue_body = get_original_content(issue.body)
-        
-        if translate_issue(issue, original_content, original_language, issue_title, issue_body):
+
+        issue_translated = translate_issue(issue, original_content, original_language, issue_title, issue_body)
+        if issue_translated:
+            print(f"Successfully translated issue #{issue_number}")
+        else:
+            print(f"Issue #{issue_number} was already translated or unchanged")
+
+        # Translate all comments on the issue
+        print(f"Translating comments on issue #{issue_number}...")
+        comments = issue.get_comments()
+        comments_translated = False
+        comment_count = 0
+
+        for comment in comments:
+            comment_count += 1
+            print(f"Processing comment #{comment.id} ({comment_count})...")
+            if translate_comment(comment):
+                comments_translated = True
+                print(f"Successfully translated comment #{comment.id}")
+            else:
+                print(f"Comment #{comment.id} was already translated or empty")
+
+        print(f"Processed {comment_count} comments on issue #{issue_number}")
+
+        # Add translated label if any translation was performed
+        if issue_translated or comments_translated:
             labels = [label.name.lower() for label in issue.labels]
             if TRANSLATED_LABEL.lower() not in labels:
                 issue.add_to_labels(TRANSLATED_LABEL)
-    
+                print(f"Added '{TRANSLATED_LABEL}' label to issue #{issue_number}")
+
     except ValueError as ve:
         print(f"Invalid number format: {ve}")
         return


### PR DESCRIPTION
## Summary

* When the **"need translation"** label is attached to an issue, the system now translates **ALL existing comments** (not just the issue body).
* Added logging to track comment translation progress.

## Problem

Previously, when attaching the **"need translation"** label to an issue with existing comments:

* Issue body was translated ✅
* Existing comments were **NOT** translated ❌

This happened because:

* `translate_issues.py` only handled the issue body.
* `translate_comments.py` required a specific `COMMENT_ID`.

## Solution

* Modified `translate_issues.py` to:

  * Translate the issue body **first**
  * Then loop through **all existing comments** on the issue and translate them.

## Test Plan

1. Create an issue with several comments
2. Attach the **"need translation"** label
3. Verify that **all comments** get translated

fixes #51 