### PR TITLE
feat: render Rimo's Note as「ノート」not「メモ」when translating to Japanese

### DIFF
--- a/src/utils/translation.py
+++ b/src/utils/translation.py
@@ -153,6 +153,32 @@ Respond with ONLY 'ja' or 'en'. Nothing else."""
         print(f"[Language Detection] Unicode fallback result: '{fallback_result}'")
         return fallback_result
 
+# Rimo-wide terminology rules applied when translating INTO Japanese.
+# Rimo's "Note" resource (a meeting recording/record) must always be rendered
+# as「ノート」, never「メモ」 — this is a product-wide naming rule.
+JAPANESE_GLOSSARY_INSTRUCTION = (
+    "Rimo product glossary (apply when translating into Japanese): when the text "
+    "refers to Rimo's \"Note\" resource (a meeting recording/record), translate it "
+    "as「ノート」, never「メモ」. Apply this to UI labels, command descriptions, and "
+    "prose alike."
+)
+
+
+def _is_japanese_target(target_language):
+    """Return True if the target language is Japanese (accepts 'ja', 'Japanese', etc.)."""
+    if not target_language:
+        return False
+    lang = target_language.strip().lower()
+    return lang.startswith("ja") or "japanese" in lang
+
+
+def _glossary_for(target_language):
+    """Return the glossary instruction for the target language, or '' if none applies."""
+    if _is_japanese_target(target_language):
+        return JAPANESE_GLOSSARY_INSTRUCTION
+    return ""
+
+
 def translate_text(text, target_language):
     try:
         url = "https://api.openai.com/v1/chat/completions"
@@ -167,6 +193,10 @@ def translate_text(text, target_language):
             "Preserve all markdown, HTML, code blocks, links, and whitespace exactly as they appear.\n"
             "Output only the translated text. Do not add explanations, preambles, notes, or any commentary."
         )
+
+        glossary = _glossary_for(target_language)
+        if glossary:
+            system_prompt += "\n" + glossary
 
         payload = {
             "model": "gpt-4o-mini",
@@ -247,10 +277,15 @@ Updated translation:"""
     try:
         url = "https://api.openai.com/v1/chat/completions"
         
+        system_content = f"You are a precise translator. Return ONLY the translated content without any explanations or comments. Translate only the changed portions to {target_lang}."
+        glossary = _glossary_for(target_lang)
+        if glossary:
+            system_content += " " + glossary
+
         payload = {
             "model": "gpt-4",
             "messages": [
-                {"role": "system", "content": f"You are a precise translator. Return ONLY the translated content without any explanations or comments. Translate only the changed portions to {target_lang}."},
+                {"role": "system", "content": system_content},
                 {"role": "user", "content": prompt}
             ],
             "temperature": 0.1


### PR DESCRIPTION
## Summary

Add a Rimo product-glossary rule to the shared translation prompts so that, **when translating into Japanese**, Rimo's **Note** resource (a meeting recording/record) is always rendered as **「ノート」**, never **「メモ」**. This is a Rimo-wide naming rule and the common base is the right place to enforce it once.

## What changed

In `src/utils/translation.py`:

- Added `JAPANESE_GLOSSARY_INSTRUCTION` plus two small helpers, `_is_japanese_target()` and `_glossary_for()`.
- `translate_text()` and `translate_incremental()` now append the glossary instruction to their system prompt **only when the target language is Japanese**.

```python
glossary = _glossary_for(target_language)
if glossary:
    system_prompt += "\n" + glossary
```

## Scope & safety

- **Japanese-only.** `_is_japanese_target()` matches `ja` / `Japanese` / `ja-JP`; `en`, `fr`, and empty targets are unaffected — non-Japanese output is byte-for-byte unchanged.
- **Product-wide by construction.** Every consumer routes through these two functions — the `translate-markdown.yml` document pipeline (`src/hooks/post_commit.py`) and the comment/issue/PR translators (`src/actions/*`) — so the rule applies everywhere without touching each repo.
- No behavioural change to language detection, incremental thresholds, or output format.

## Verification

- `python -c "import ast; ast.parse(open('src/utils/translation.py').read())"` — syntax OK.
- Helper unit check: `ja`/`Japanese`/`JA`/`ja-JP` → glossary applied; `en`/`fr`/`French`/empty/`None` → not applied.
- Live smoke test against several English doc snippets mentioning notes confirms output uses 「ノート」 and never 「メモ」.
