### PR TITLE
fix(ci): point translate workflows at rimo/bilingual-github after org rename

### DIFF
--- a/.github/workflows/translate-markdown.yml
+++ b/.github/workflows/translate-markdown.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout Translation Tools Repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          repository: rimoapp/bilingual-github
+          repository: rimo/bilingual-github
           path: bilingual-github
           token: ${{ steps.generate_token.outputs.token }}
           persist-credentials: false

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          repository: rimoapp/bilingual-github
+          repository: rimo/bilingual-github
           path: bilingual-github
           token: ${{ secrets.REPO_TOKEN }}
       


### PR DESCRIPTION
## Problem
Translate workflows have been failing since the `rimoapp` org was renamed to `rimo` (~2026-06-23 13:00 UTC) — runs die at reusable-workflow resolution ("workflow file issue", zero jobs).

## Root cause
GitHub Actions does **not** follow the org-rename redirect when resolving a reusable-workflow `uses:` reference, even though git and the REST API do. This repo's workflows still reference the old `rimoapp` org.

## Fix
Replace `rimoapp/bilingual-github` → `rimo/bilingual-github` in the affected workflow file(s):
- `.github/workflows/translate-markdown.yml`
- `.github/workflows/translate.yml`

Part of an org-wide sweep (all repos calling bilingual-github broke at the rename).